### PR TITLE
Add new commands to restart and get logs of a server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,7 @@ name = "besta-fera"
 version = "0.1.0"
 dependencies = [
  "bollard",
+ "futures-util",
  "poise",
  "strum",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 bollard = "0.18.1"
+futures-util = "0.3.31"
 poise = "0.6.1"
 strum = { version = "0.26", features = ["derive"] }
 tokio = { version = "1.42.0", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Discord bot to manage Minecraft servers on my [homelab](https://github.com/bltav
 ## Available commands
 - `/start <server>`: Start a server
 - `/stop <server>`: Stop a server
+- `/logs <server>`: Get the recent logs of a server
 - `/status`: Get the status of a server
 
 ## Installation
@@ -14,7 +15,7 @@ Open the Discord Developer Portal and create a new bot. Use the token to configu
 Enable on OAuth2 the `bot` scope and `applications.commands` permissions: 
   - Slash Commands
   - Send Messages
-  - 
+
 Then paste the link on the channel to invite it to the server.
 
 ### Running


### PR DESCRIPTION
Add a new command to get the logs of a server as an Embed.

* Add a new `logs` command to `src/main.rs` to fetch and display the logs of a specified server.
* Use markdown code fences to format the logs in the embed description.
* Update the command list in the `main` function to include the new `logs` command.

